### PR TITLE
libretro: Add no sprite limit core option

### DIFF
--- a/platforms/libretro/libretro.cpp
+++ b/platforms/libretro/libretro.cpp
@@ -88,6 +88,7 @@ static void fallback_log(enum retro_log_level level, const char *fmt, ...)
 static const struct retro_variable vars[] = {
     { "gearcoleco_timing", "Refresh Rate (restart); Auto|NTSC (60 Hz)|PAL (50 Hz)" },
     { "gearcoleco_up_down_allowed", "Allow Up+Down / Left+Right; Disabled|Enabled" },
+    { "gearcoleco_no_sprite_limit", "No Sprite Limit; Disabled|Enabled" },
     { NULL }
 };
 
@@ -399,6 +400,17 @@ static void check_variables(void)
             config.region = Cartridge::CartridgePAL;
         else
             config.region = Cartridge::CartridgeUnknownRegion;
+    }
+
+    var.key = "gearcoleco_no_sprite_limit";
+    var.value = NULL;
+
+    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+    {
+        if (strcmp(var.value, "Enabled") == 0)
+            core->GetVideo()->SetNoSpriteLimit(true);
+        else
+            core->GetVideo()->SetNoSpriteLimit(false);
     }
 }
 

--- a/src/Video.cpp
+++ b/src/Video.cpp
@@ -44,6 +44,8 @@ Video::Video(Memory* pMemory, Processor* pProcessor)
     m_iMode = 0;
     m_bDisplayEnabled = false;
     m_bSpriteOvrRequest = false;
+    m_bNoSpriteLimit = false;
+
     for (int i = 0; i < 48; i++)
         m_CustomPalette[i] = 0;
     m_pCurrentPalette = const_cast<u8*>(kPalette_888_coleco);
@@ -96,6 +98,11 @@ void Video::Reset(bool bPAL)
     m_Timing[TIMING_VINT] = 25;
     m_Timing[TIMING_RENDER] = 195;
     m_Timing[TIMING_DISPLAY] = 37;
+}
+
+void Video::SetNoSpriteLimit(bool noSpriteLimit)
+{
+    m_bNoSpriteLimit = noSpriteLimit;
 }
 
 bool Video::Tick(unsigned int clockCycles)
@@ -451,7 +458,7 @@ void Video::RenderSprites(int line)
             else
                 sprite_pixel = IsSetBit(m_pVdpVRAM[sprite_line_addr + 16], 15 - tile_x_adjusted);
 
-            if (sprite_pixel && (sprite_count < 5))
+            if (sprite_pixel && ((sprite_count < 5) || m_bNoSpriteLimit))
             {
                 if (!IsSetBit(m_pInfoBuffer[pixel], 0) && (sprite_color > 0))
                 {

--- a/src/Video.h
+++ b/src/Video.h
@@ -47,6 +47,7 @@ public:
     void Render16bit(u16* srcFrameBuffer, u8* dstFrameBuffer, GC_Color_Format pixelFormat, int size);
     void SetCustomPalette(GC_Color* palette);
     void SetPredefinedPalette(int palette);
+    void SetNoSpriteLimit(bool noSpriteLimit);
 
 private:
     void ScanLine(int line);
@@ -90,6 +91,7 @@ private:
     int m_Timing[3];
     bool m_bDisplayEnabled;
     bool m_bSpriteOvrRequest;
+    bool m_bNoSpriteLimit;
 
     u16 m_palette_565_rgb[16];
     u16 m_palette_555_rgb[16];


### PR DESCRIPTION
This PR implements a No Sprite Limit core option to the Libretro core, to turn off the 4 sprite per line limitation that is present on original hardware which results in less sprite flicker. 

A good test case I used was "BurgerTime" as this game introduces some very notable flickering immediately upon starting, and the core option removes this.

I did not add a getter method as the libretro implementation does not utilize one, and I was not sure if you would prefer an inline function or not as some of the other getters use.