### PR TITLE
rpm: add libatomic build dependency

### DIFF
--- a/platforms/linux/rpm/gearcoleco.spec
+++ b/platforms/linux/rpm/gearcoleco.spec
@@ -13,6 +13,7 @@ BuildRequires:  make
 BuildRequires:  pkgconf-pkg-config
 BuildRequires:  mesa-libGL-devel
 BuildRequires:  SDL3-devel
+BuildRequires:  libatomic
 
 Requires:       mesa-libGL
 Requires:       SDL3


### PR DESCRIPTION
Gearcoleco does not currently require libatomic, but the other Gear emulators already declare it in their RPM build dependencies.

Since future ADAM and ADAMnet work may introduce code paths that benefit from explicit atomic runtime support on some architectures, add:

BuildRequires: libatomic

This keeps the RPM packaging aligned across all five Gear emulators and prepares Gearcoleco for future development without changing current runtime behavior.