### PR TITLE
build: link libatomic on Linux

### DIFF
--- a/platforms/shared/makefiles/Makefile.common
+++ b/platforms/shared/makefiles/Makefile.common
@@ -64,7 +64,7 @@ endif
 
 ifeq ($(UNAME_S), Linux)
     PLATFORM = "Linux"
-    LDFLAGS += -lGL -ldl `pkg-config --libs sdl3`
+    LDFLAGS += -lGL -ldl -latomic `pkg-config --libs sdl3`
     CPPFLAGS += `pkg-config --cflags sdl3`
     TARGET := $(TARGET_NAME)
 else ifeq ($(UNAME_S), Darwin)


### PR DESCRIPTION
The other Gear emulators already link `libatomic` explicitly for Linux builds.

Add `-latomic` to Gearcoleco's Linux linker flags as well, keeping the shared build configuration consistent across the five emulators and preparing the Linux build for future **ADAM and ADAMnet** development..